### PR TITLE
Update AccuracyFix.sma

### DIFF
--- a/cstrike/addons/amxmodx/scripting/AccuracyFix.sma
+++ b/cstrike/addons/amxmodx/scripting/AccuracyFix.sma
@@ -5,7 +5,7 @@
 #define MAX_WEAPONS 32
 
 // Weapon Slots by index
-new const g_iWeaponSlot[] = {0, 2, 0, 1, 4, 1, 5, 1, 1, 4, 2, 2, 1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 1, 1, 1, 4, 2, 1, 1, 3, 1};
+new const g_iWeaponSlot[MAX_WEAPONS+1] = {0, 2, 0, 1, 4, 1, 5, 1, 1, 4, 2, 2, 1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 1, 1, 1, 4, 2, 1, 1, 3, 1, 0, 0};
 
 // Player Weapon Index
 new g_iPlayerWeaponId[MAX_PLAYERS+1] = {0, ...};


### PR DESCRIPTION
fix for regular error
```
[AMXX] Run time error 4: index out of bounds
[AMXX]    [0] AccuracyFix.sma::plugin_init (line 24)
```
The plugin throws regular error on every run because the size of the g_iWeaponSlot array does not match the logic in the for() loop on line 22/24. This PR fixes this issue by adding the two missing elements to the array.